### PR TITLE
Restore SingleQuotes for JSON attributes with regression tests

### DIFF
--- a/src/Ramstack.HtmxToolkit/TagHelpers/HtmxRequestTagHelper.cs
+++ b/src/Ramstack.HtmxToolkit/TagHelpers/HtmxRequestTagHelper.cs
@@ -62,7 +62,9 @@ public sealed class HtmxRequestTagHelper : TagHelper
         {
             var info = HtmxRequestJsonSerializerContext.Default.HtmxRequestData;
             var request = new HtmlString(JsonSerializer.Serialize(_request, info));
-            output.Attributes.SetAttribute(new TagHelperAttribute("hx-request", request));
+
+            output.Attributes.SetAttribute(
+                new TagHelperAttribute("hx-request", request, HtmlAttributeValueStyle.SingleQuotes));
         }
 
         return Task.CompletedTask;

--- a/tests/Ramstack.HtmxToolkit.Tests/HtmxConfigTagHelperTests.cs
+++ b/tests/Ramstack.HtmxToolkit.Tests/HtmxConfigTagHelperTests.cs
@@ -50,6 +50,17 @@ public class HtmxConfigTagHelperTests
     }
 
     [Test]
+    public async Task ProcessAsync_UsesSingleQuotesForJsonAttribute()
+    {
+        var output = TestHelper.CreateTagHelperOutput();
+        var helper = new HtmxConfigTagHelper(new StubAntiforgery());
+
+        await helper.ProcessAsync(TestHelper.CreateTagHelperContext(), output);
+
+        Assert.That(output.Attributes["content"]!.ValueStyle, Is.EqualTo(HtmlAttributeValueStyle.SingleQuotes));
+    }
+
+    [Test]
     public async Task ProcessAsync_SerializesConfiguredOptions()
     {
         var helper = new HtmxConfigTagHelper(new StubAntiforgery())

--- a/tests/Ramstack.HtmxToolkit.Tests/HtmxHeaderTagHelperTests.cs
+++ b/tests/Ramstack.HtmxToolkit.Tests/HtmxHeaderTagHelperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Ramstack.HtmxToolkit.Tests;
 
@@ -44,6 +45,23 @@ public class HtmxHeaderTagHelperTests
 
         Assert.That(helper.Headers, Has.Count.EqualTo(1));
         Assert.That(helper.Headers["X-CUSTOM"], Is.EqualTo("second"));
+    }
+
+    [Test]
+    public async Task ProcessAsync_UsesSingleQuotesForJsonAttribute()
+    {
+        var output = TestHelper.CreateTagHelperOutput();
+        var helper = new HtmxHeaderTagHelper
+        {
+            Headers =
+            {
+                ["X-Custom"] = "value"
+            }
+        };
+
+        await helper.ProcessAsync(TestHelper.CreateTagHelperContext(), output);
+
+        Assert.That(output.Attributes["hx-headers"]!.ValueStyle, Is.EqualTo(HtmlAttributeValueStyle.SingleQuotes));
     }
 
     [Test]

--- a/tests/Ramstack.HtmxToolkit.Tests/HtmxRequestTagHelperTests.cs
+++ b/tests/Ramstack.HtmxToolkit.Tests/HtmxRequestTagHelperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Ramstack.HtmxToolkit.Tests;
 
@@ -47,6 +48,20 @@ public class HtmxRequestTagHelperTests
         Assert.That(json["timeout"].GetInt32(), Is.EqualTo(500));
         Assert.That(json.ContainsKey("credentials"), Is.False);
         Assert.That(json.ContainsKey("noHeaders"), Is.False);
+    }
+
+    [Test]
+    public async Task ProcessAsync_UsesSingleQuotesForJsonAttribute()
+    {
+        var output = TestHelper.CreateTagHelperOutput();
+        var helper = new HtmxRequestTagHelper
+        {
+            Timeout = 500
+        };
+
+        await helper.ProcessAsync(TestHelper.CreateTagHelperContext(), output);
+
+        Assert.That(output.Attributes["hx-request"]!.ValueStyle, Is.EqualTo(HtmlAttributeValueStyle.SingleQuotes));
     }
 
     [Test]

--- a/tests/Ramstack.HtmxToolkit.Tests/HtmxValsTagHelperTests.cs
+++ b/tests/Ramstack.HtmxToolkit.Tests/HtmxValsTagHelperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Ramstack.HtmxToolkit.Tests;
 
@@ -35,6 +36,23 @@ public class HtmxValsTagHelperTests
         var json = JsonHelper.ParseJson(serialized);
         Assert.That(json["категория"].GetString(), Is.EqualTo("Детские книги '<script>\" &"));
         Assert.That(json["sort"].GetString(), Is.EqualTo("title"));
+    }
+
+    [Test]
+    public async Task ProcessAsync_UsesSingleQuotesForJsonAttribute()
+    {
+        var output = TestHelper.CreateTagHelperOutput();
+        var helper = new HtmxValsTagHelper
+        {
+            Values =
+            {
+                ["sort"] = "title"
+            }
+        };
+
+        await helper.ProcessAsync(TestHelper.CreateTagHelperContext(), output);
+
+        Assert.That(output.Attributes["hx-vals"]!.ValueStyle, Is.EqualTo(HtmlAttributeValueStyle.SingleQuotes));
     }
 
     [Test]


### PR DESCRIPTION
The hx-request attribute lost its SingleQuotes style by mistake.
Restore it and add a test for each JSON-emitting tag helper asserting
the attribute uses SingleQuotes so this regression can't slip through
again.
